### PR TITLE
Add workflow to manage surge deployments

### DIFF
--- a/.github/workflows/manage-surge-deployments.yml
+++ b/.github/workflows/manage-surge-deployments.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   list_deployments:
-    if: ${{ github.event.inputs.teardown }} != 'true'
+    if: github.event.inputs.teardown != 'true'
     runs-on: ubuntu-20.04
     steps:
       - name: List deployments
@@ -17,7 +17,7 @@ jobs:
           npx surge list --token ${{ secrets.SURGE_TOKEN }}
 
   teardown_deployments:
-    if: ${{ github.event.inputs.teardown }} == 'true'
+    if: github.event.inputs.teardown == 'true'
     runs-on: ubuntu-20.04
     steps:
       - name: Teardown deployments

--- a/.github/workflows/manage-surge-deployments.yml
+++ b/.github/workflows/manage-surge-deployments.yml
@@ -2,18 +2,24 @@ name: Manage Surge Deployments
 on:
   workflow_dispatch:
     inputs:
-      use-default-surge-account:
-        description: 'If true, use the surge-preview default account'
+      teardown:
+        description: 'If true, perform a deployment teardown. Otherwise, list deployments'
         required: true
         default: 'false'
 
 jobs:
   list_deployments:
+    if: ${{ github.event.inputs.teardown }} != 'true'
     runs-on: ubuntu-20.04
     steps:
-      - name: Select deployment account
-        run: |
-          echo "Use default surge account? ${{ github.event.inputs.use-default-surge-account }}"
       - name: List deployments
         run: |
           npx surge list --token ${{ secrets.SURGE_TOKEN }}
+
+  teardown_deployments:
+    if: ${{ github.event.inputs.teardown }} = 'true'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Teardown deployments
+        run: |
+          echo "Simulate"

--- a/.github/workflows/manage-surge-deployments.yml
+++ b/.github/workflows/manage-surge-deployments.yml
@@ -1,6 +1,11 @@
 name: Manage Surge Deployments
 on:
   workflow_dispatch:
+#    inputs:
+#      type:
+#        description: 'New version type [new-version | major | minor | patch]'
+#        required: true
+#        default: 'patch'
 
 jobs:
   list_deployments:
@@ -8,4 +13,4 @@ jobs:
     steps:
       - name: List deployments
         run: |
-          npx surge list --token ${{ secrets.SURGE_TOKEN }}
+          npx surge list --token "${{ secrets.SURGE_TOKEN }}"

--- a/.github/workflows/manage-surge-deployments.yml
+++ b/.github/workflows/manage-surge-deployments.yml
@@ -5,6 +5,9 @@ on:
       teardown:
         description: 'If true, perform a deployment teardown. Otherwise, list deployments'
         required: false
+      deployment-urls:
+        description: 'Urls of the deployments (separated by a space) to teardown.'
+        required: false
 
 jobs:
   list_deployments:
@@ -13,7 +16,7 @@ jobs:
     steps:
       - name: List deployments
         run: |
-          npx surge list --token ${{ secrets.SURGE_TOKEN }}
+          npx surge --token ${{ secrets.SURGE_TOKEN }} list
 
   teardown_deployments:
     if: github.event.inputs.teardown == 'true'
@@ -21,4 +24,4 @@ jobs:
     steps:
       - name: Teardown deployments
         run: |
-          echo "Simulate"
+          npx surge --token ${{ secrets.SURGE_TOKEN }} teardown ${{ github.event.inputs.deployment-urls }}

--- a/.github/workflows/manage-surge-deployments.yml
+++ b/.github/workflows/manage-surge-deployments.yml
@@ -5,7 +5,6 @@ on:
       teardown:
         description: 'If true, perform a deployment teardown. Otherwise, list deployments'
         required: false
-        default: 'false'
 
 jobs:
   list_deployments:

--- a/.github/workflows/manage-surge-deployments.yml
+++ b/.github/workflows/manage-surge-deployments.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - name: List deployments
         run: |
-          npx surge list --token "${{ secrets.SURGE_TOKEN }}"
+          npx surge list --token ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/manage-surge-deployments.yml
+++ b/.github/workflows/manage-surge-deployments.yml
@@ -1,16 +1,19 @@
 name: Manage Surge Deployments
 on:
   workflow_dispatch:
-#    inputs:
-#      type:
-#        description: 'New version type [new-version | major | minor | patch]'
-#        required: true
-#        default: 'patch'
+    inputs:
+      use-default-surge-account:
+        description: 'If true, use the surge-preview default account'
+        required: true
+        default: 'false'
 
 jobs:
   list_deployments:
     runs-on: ubuntu-20.04
     steps:
+      - name: Select deployment account
+        run: |
+          echo "Use default surge account? ${{ github.event.inputs.use-default-surge-account }}"
       - name: List deployments
         run: |
           npx surge list --token ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/manage-surge-deployments.yml
+++ b/.github/workflows/manage-surge-deployments.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       teardown:
         description: 'If true, perform a deployment teardown. Otherwise, list deployments'
-        required: true
+        required: false
         default: 'false'
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
           npx surge list --token ${{ secrets.SURGE_TOKEN }}
 
   teardown_deployments:
-    if: ${{ github.event.inputs.teardown }} = 'true'
+    if: ${{ github.event.inputs.teardown }} == 'true'
     runs-on: ubuntu-20.04
     steps:
       - name: Teardown deployments

--- a/.github/workflows/manage-surge-deployments.yml
+++ b/.github/workflows/manage-surge-deployments.yml
@@ -5,8 +5,8 @@ on:
       teardown:
         description: 'If true, perform a deployment teardown. Otherwise, list deployments'
         required: false
-      deployment-urls:
-        description: 'Urls of the deployments (separated by a space) to teardown.'
+      deployment-url:
+        description: 'Url of the deployment to teardown.'
         required: false
 
 jobs:
@@ -24,4 +24,4 @@ jobs:
     steps:
       - name: Teardown deployments
         run: |
-          npx surge --token ${{ secrets.SURGE_TOKEN }} teardown ${{ github.event.inputs.deployment-urls }}
+          npx surge --token ${{ secrets.SURGE_TOKEN }} teardown ${{ github.event.inputs.deployment-url }}


### PR DESCRIPTION
Let us list and teardown deployments by triggering workflow manually.

I have teardown deployments related to closed PR with the workflow.
In the future, this could be improved by periodically running the workflow and make it teardown closed PR (see also https://github.com/bonitasoft/bonita-documentation-site/issues/178)

**Before teardown**
![before_teardown](https://user-images.githubusercontent.com/27200110/119937138-899b9900-bf8a-11eb-9900-b4ed66d6a916.png)

**After teardown**
![after_teardown](https://user-images.githubusercontent.com/27200110/119937134-89030280-bf8a-11eb-8b15-bb7481ca6477.png)

**Opened PR**
![image](https://user-images.githubusercontent.com/27200110/119937217-b2bc2980-bf8a-11eb-877c-908df4aaa982.png)


