### PR TITLE
[INFRA] Add a GH WF to teardown old surge deployments

### DIFF
--- a/.github/workflows/teardown-inactive-surge-deployments.yml
+++ b/.github/workflows/teardown-inactive-surge-deployments.yml
@@ -1,0 +1,17 @@
+name: Teardown old surge deployments
+
+on:
+  schedule:
+    - cron: '0 3 * * 6'
+  workflow_dispatch:
+
+jobs:
+  teardown_old_deployments:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Teardown surge deployements created more than 1 month ago
+        uses: adrianjost/actions-surge.sh-teardown@v1.0.3
+        with:
+          regex: '[1-9]+ month.? ago'
+        env:
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
We already have a workflow to list deployments and teardown deployments one by one.
This new workflow launched on regular basis or on demand ensures that we don't keep old deployments.

### Notes
Inspired from https://github.com/bonitasoft/bonita-documentation-site/pull/316