### PR TITLE
[INFRA] Update the release-drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,6 +18,7 @@ categories:
       - chore
       - internal
   - title: 📦 Dependency updates
+    collapse-after: 2
     labels:
       - dependencies
 exclude-labels:
@@ -26,7 +27,13 @@ exclude-labels:
   - skip-changelog
   - reverted
   - wontfix
-
+# Exclude specific usernames from the generated $CONTRIBUTORS variable.
+# https://github.com/release-drafter/release-drafter/tree/master#exclude-contributors
+exclude-contributors:
+    - 'dependabot'
+  #  - 'dependabot[bot]'
+  #  - '@dependabot'
+#  - '@dependabot[bot]'
 template: |
   **TODO: add a short description about the release content - important for url preview**
   This new release focuses on .... **or something similar**
@@ -41,3 +48,6 @@ template: |
   # What's Changed
   $CHANGES
 
+  **TODO: check previous and next tag in the link below**
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION

--- a/.github/workflows/fill-gh-draft-release.yml
+++ b/.github/workflows/fill-gh-draft-release.yml
@@ -1,6 +1,7 @@
 name: Fill GitHub Draft Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
Match the bpmn-visualization current configuration
  - Collapse dependencies
  - Add changelog
  - dependabot exclude from contributors (but no dependabot replacers)

Allow to run the GitHub workflow on demand