### PR TITLE
[INFRA] List packages and tools installed in gh action runners

### DIFF
--- a/.github/workflows/list-installed-packages-and-tools.yml
+++ b/.github/workflows/list-installed-packages-and-tools.yml
@@ -1,0 +1,40 @@
+name: List installed packages and tools
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '10 1 * * *'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/list-installed-packages-and-tools.yml'
+
+jobs:
+  windows_env:
+    runs-on: windows-2019
+    steps:
+      # The 1st powershell run is very slow, use this one to warm the process
+      # Next powershell calls will execute right away
+      - name: Ping
+        run: echo "I am alive"
+      - name: List installed browsers (64 bits)
+        shell: powershell
+        run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where { $_.DisplayName -like "*Chrome*" -or $_.DisplayName -like "*Edge*"} | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
+      - name: List installed browsers (32/64 bits)
+        shell: powershell
+        run: Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Where { $_.DisplayName -like "*Chrome*" -or $_.DisplayName -like "*Edge*"} | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
+      - name: List all installed software (64 bits)
+        shell: powershell
+        run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
+      - name: List all installed software (32/64 bits)
+        shell: powershell
+        run: Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
+
+  ubuntu_env:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check Chrome
+        run: apt show google-chrome-stable
+      - name: List all software
+        run: apt list


### PR DESCRIPTION
Run on a daily basis to help detect environment changes. Logs will help doing diff to detect softwares and tools changes.
Not done on macOS.

based on implementation of https://github.com/tbouffard/playground-release-drafter-and-gh-pages/pull/89covers https://github.com/process-analytics/bpmn-visualization-js/issues/1933


### Additional ideas
Initially, the purpose of this PR was to check the chrome and edge browser versionsThe first idea that came to me was to open a browser and check the version. That could be done with playwright and take a screenshot of the page and store it as an artifact.For instance, the following urls provide the browser version- chrome://settings/help- brave://settings/help- edge??

Listing softwares and tools with a CLI is less painfulll and provide information for more elements, so so I gave up on that idea