### PR TITLE
[FIX] Surge tools action - add protocol in the surge-preview-url output

### DIFF
--- a/.github/actions/surge-preview-tools/dist/index.js
+++ b/.github/actions/surge-preview-tools/dist/index.js
@@ -9096,7 +9096,7 @@ try {
   // the token must be set
   const surgeToken = core.getInput('surge-token');
   core.setSecret(surgeToken);
-  const isSurgeTokenValid = surgeToken && checkLogin(surgeToken);
+  const isSurgeTokenValid = checkLogin(surgeToken);
   core.info(`surge token valid? ${isSurgeTokenValid}`)
   core.setOutput("surge-token-valid", isSurgeTokenValid);
 

--- a/.github/actions/surge-preview-tools/dist/index.js
+++ b/.github/actions/surge-preview-tools/dist/index.js
@@ -9089,14 +9089,14 @@ try {
   // Compute the 'preview url', as built by the surge-preview action
   const repoOwner = github.context.repo.owner.replace(/\./g, '-');
   const repoName = github.context.repo.repo.replace(/\./g, '-');
-  const url = `${repoOwner}-${repoName}-${github.context.job}-pr-${payload.number}.surge.sh`;
+  const url = `https://${repoOwner}-${repoName}-${github.context.job}-pr-${payload.number}.surge.sh`;
   core.setOutput('preview-url', url);
   core.info(`Computed preview url: ${url}`);
 
   // the token must be set
   const surgeToken = core.getInput('surge-token');
   core.setSecret(surgeToken);
-  const isSurgeTokenValid = checkLogin(surgeToken);
+  const isSurgeTokenValid = surgeToken && checkLogin(surgeToken);
   core.info(`surge token valid? ${isSurgeTokenValid}`)
   core.setOutput("surge-token-valid", isSurgeTokenValid);
 

--- a/.github/actions/surge-preview-tools/src/index.js
+++ b/.github/actions/surge-preview-tools/src/index.js
@@ -14,7 +14,7 @@ try {
   // the token must be set
   const surgeToken = core.getInput('surge-token');
   core.setSecret(surgeToken);
-  const isSurgeTokenValid = surgeToken && checkLogin(surgeToken);
+  const isSurgeTokenValid = checkLogin(surgeToken);
   core.info(`surge token valid? ${isSurgeTokenValid}`)
   core.setOutput("surge-token-valid", isSurgeTokenValid);
 

--- a/.github/actions/surge-preview-tools/src/index.js
+++ b/.github/actions/surge-preview-tools/src/index.js
@@ -7,14 +7,14 @@ try {
   // Compute the 'preview url', as built by the surge-preview action
   const repoOwner = github.context.repo.owner.replace(/\./g, '-');
   const repoName = github.context.repo.repo.replace(/\./g, '-');
-  const url = `${repoOwner}-${repoName}-${github.context.job}-pr-${payload.number}.surge.sh`;
+  const url = `https://${repoOwner}-${repoName}-${github.context.job}-pr-${payload.number}.surge.sh`;
   core.setOutput('preview-url', url);
   core.info(`Computed preview url: ${url}`);
 
   // the token must be set
   const surgeToken = core.getInput('surge-token');
   core.setSecret(surgeToken);
-  const isSurgeTokenValid = checkLogin(surgeToken);
+  const isSurgeTokenValid = surgeToken && checkLogin(surgeToken);
   core.info(`surge token valid? ${isSurgeTokenValid}`)
   core.setOutput("surge-token-valid", isSurgeTokenValid);
 

--- a/.github/workflows/surge-preview-for-pr.yml
+++ b/.github/workflows/surge-preview-for-pr.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: ./.github/actions/surge-preview-tools
         id: surge-preview-tools
         with:
-          surge-token: ${{ secrets.SURGE_TOKEN }}
+          surge-token: ${{ secrets.SURGE_TOKEN_UNKNOWN }}
       - name: Echo surge preview tools output
         run: |
           echo "can-run-surge-command: ${{ steps.surge-preview-tools.outputs.can-run-surge-command }}"

--- a/.github/workflows/surge-preview-for-pr.yml
+++ b/.github/workflows/surge-preview-for-pr.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: ./.github/actions/surge-preview-tools
         id: surge-preview-tools
         with:
-          surge-token: ${{ secrets.SURGE_TOKEN_UNKNOWN }}
+          surge-token: ${{ secrets.SURGE_TOKEN }}
       - name: Echo surge preview tools output
         run: |
           echo "can-run-surge-command: ${{ steps.surge-preview-tools.outputs.can-run-surge-command }}"


### PR DESCRIPTION
Add `https` at the beginning of the output to have a valid url.