### PR TITLE
[INFRA] Improve full changelog visibility in release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -48,5 +48,4 @@ template: |
   # What's Changed
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION
-  
   $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -39,13 +39,14 @@ template: |
   **TODO: review the contributors list (remove ALL bots and avoid duplicates)**
   Thanks to all the contributors of this release 🌈: $CONTRIBUTORS
 
+  **TODO: check previous and next tag in the "full changelog" link in the "What's changed section"**
+
   # Highlights
 
   **TODO: add screenshots and user oriented info**
 
   # What's Changed
-  $CHANGES
-
-  **TODO: check previous and next tag in the link below**
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION
+  
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -48,4 +48,5 @@ template: |
   # What's Changed
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION
+
   $CHANGES


### PR DESCRIPTION
Avoid forgetting to delete the reminder comments and not updating the full changelog link.

This is what we have done manually in https://github.com/process-analytics/bpmn-visualization-js/releases/tag/v0.26.0