### PR TITLE
[DOC] Do not add dev dependencies to release notes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,14 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 2
     versioning-strategy: increase
-    rebase-strategy: "disabled"    
+    rebase-strategy: "disabled"
     commit-message:
       prefix: "[INFRA] prod -"
       prefix-development: "[INFRA] dev -"
+    labels:
+      - dependencies
+      - javascript
+      - skip-changelog
     reviewers:
       - process-analytics/pa-collaborators
 
@@ -21,8 +25,12 @@ updates:
       interval: "weekly"
       day: sunday
     open-pull-requests-limit: 2
-    rebase-strategy: "disabled"    
+    rebase-strategy: "disabled"
     commit-message:
       prefix: "[INFRA] gha -"
+    labels:
+      - dependencies
+      - github_actions
+      - skip-changelog
     reviewers:
       - process-analytics/pa-collaborators

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     versioning-strategy: increase
     rebase-strategy: "disabled"
     commit-message:
-      prefix: "[INFRA] prod -"
+      prefix: "[INFRA] deps -"
       prefix-development: "[INFRA] dev -"
     labels:
       - dependencies

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -35,7 +35,7 @@ template: |
   **TODO: review the contributors list (remove ALL bots and avoid duplicates)**
   Thanks to all the contributors of this release 🌈: $CONTRIBUTORS
 
-  **TODO: add milestone id when publishing**
+  **TODO: use the right milestone id and ensure the version is the right one**
   See [milestone $NEXT_PATCH_VERSION](https://github.com/$OWNER/$REPOSITORY/milestone/x?closed=1) to get the list of issues covered by this release.
 
   **TODO: check previous and next tag in the "full changelog" link in the "What's changed section"**

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -26,6 +26,8 @@ exclude-contributors:
   - 'dependabot'
   - 'dependabot[bot]'
 template: |
+  EXTRA: this will be removed in the final configuration!
+  
   **TODO: add a short description about the release content - important for url preview**
   This new release focuses on .... **or something similar**
   This new version brings improvements to ...

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,30 +9,32 @@ categories:
     labels:
       - bug
   - title: 📝 Documentation
-    label: documentation
+    labels:
+      - documentation
+  - title: 📦 Dependency updates
+    labels:
+      - dependencies
   - title: 👻 Maintenance
     labels:
       - chore
       - refactoring
-  - title: 📦 Dependency updates
-    collapse-after: 2
-    labels:
-      - dependencies
 exclude-labels:
-  - invalid
   - skip-changelog
-  - reverted
 # Exclude specific usernames from the generated $CONTRIBUTORS variable.
 # https://github.com/release-drafter/release-drafter/tree/master#exclude-contributors
 exclude-contributors:
-    - 'dependabot'
-    - 'dependabot[bot]'
+  - 'dependabot'
+  - 'dependabot[bot]'
 template: |
   **TODO: add a short description about the release content - important for url preview**
   This new release focuses on .... **or something similar**
+  This new version brings improvements to ...
 
   **TODO: review the contributors list (remove ALL bots and avoid duplicates)**
   Thanks to all the contributors of this release 🌈: $CONTRIBUTORS
+
+  **TODO: add milestone id when publishing**
+  See [milestone $NEXT_PATCH_VERSION](https://github.com/$OWNER/$REPOSITORY/milestone/x?closed=1) to get the list of issues covered by this release.
 
   **TODO: check previous and next tag in the "full changelog" link in the "What's changed section"**
 


### PR DESCRIPTION
Dependabot now creates Pull Requests that are not present in the release notes.
The release notes doesn't collapse the dependency updates list.


refs https://github.com/process-analytics/bpmn-visualization-R/issues/104
refs https://github.com/process-analytics/bpmn-visualization-js/issues/2208

