### PR TITLE
chore: ensure that the PR title follows "Conventional Commits"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
     versioning-strategy: increase
     rebase-strategy: "disabled"
     commit-message:
-      prefix: "[INFRA] deps -"
-      prefix-development: "[INFRA] dev -"
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     labels:
       - dependencies
       - javascript
@@ -27,7 +27,7 @@ updates:
     open-pull-requests-limit: 2
     rebase-strategy: "disabled"
     commit-message:
-      prefix: "[INFRA] gha -"
+      prefix: "chore(gha)"
     labels:
       - dependencies
       - github_actions

--- a/.github/workflows/post-release-update_bpmn_visualization_version_in_Examples_repo.yml
+++ b/.github/workflows/post-release-update_bpmn_visualization_version_in_Examples_repo.yml
@@ -50,13 +50,13 @@ jobs:
         uses: peter-evans/create-pull-request@v4.2.3
         with:
           token: ${{ secrets.GH_RELEASE_TOKEN }}
-          commit-message: "[INFRA] Update bpmn-visualization version to ${{ env.VERSION }}"
+          commit-message: "chore(deps): update bpmn-visualization version to ${{ env.VERSION }}"
           committer: "${{ vars.PA_BOT_NAME }} <${{ vars.PA_BOT_EMAIL }}>"
           author: "${{ vars.PA_BOT_NAME }} <${{ vars.PA_BOT_EMAIL }}>"
           branch: "infra/update_bpmn_visualization_to_${{ env.VERSION }}"
           delete-branch: true
           base: "master"
-          title: "[INFRA] Update bpmn-visualization version to ${{ env.VERSION }}"
+          title: "chore(deps): update bpmn-visualization version to ${{ env.VERSION }}"
           body: "https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/infra/update_bpmn_visualization_to_${{ env.VERSION }}/examples/index.html"
           labels: "enhancement"
           team-reviewers: pa-collaborators

--- a/.github/workflows/post-release-update_bpmn_visualization_version_in_R_repo.yml
+++ b/.github/workflows/post-release-update_bpmn_visualization_version_in_R_repo.yml
@@ -40,13 +40,13 @@ jobs:
         uses: peter-evans/create-pull-request@v4.2.3
         with:
           token: ${{ secrets.GH_RELEASE_TOKEN }}
-          commit-message: "[INFRA] Bump bpmn-visualization from ${{ env.OLD_VERSION }} to ${{ env.VERSION }}"
+          commit-message: "chore(deps): bump bpmn-visualization from ${{ env.OLD_VERSION }} to ${{ env.VERSION }}"
           committer: "${{ vars.PA_BOT_NAME }} <${{ vars.PA_BOT_EMAIL }}>"
           author: "${{ vars.PA_BOT_NAME }} <${{ vars.PA_BOT_EMAIL }}>"
           branch: "infra/bump_bpmn_visualization_from_${{ env.OLD_VERSION }}_to_${{ env.VERSION }}"
           delete-branch: true
           base: "master"
-          title: "[INFRA] Bump bpmn-visualization from ${{ env.OLD_VERSION }} to ${{ env.VERSION }}"
+          title: "chore(deps): bump bpmn-visualization from ${{ env.OLD_VERSION }} to ${{ env.VERSION }}"
           body: "Perform what we have to do to update bpmn-visualization-js in the bpmn-visualization-R package. bpmn-visualization is updated from https://cdn.jsdelivr.net/npm/bpmn-visualization@${{ env.VERSION }}/dist/bpmn-visualization.min.js."
           labels: "dependencies"
           team-reviewers: pa-collaborators

--- a/.github/workflows/pr-metadata-checks.yml
+++ b/.github/workflows/pr-metadata-checks.yml
@@ -1,0 +1,14 @@
+name: Check Pull Request Metadata
+on:
+  pull_request_target:
+    # trigger when the PR title changes
+    types: [opened, edited, reopened]
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
+    steps:
+      - name: Check Pull Request title
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v2

--- a/.github/workflows/release-R.yml
+++ b/.github/workflows/release-R.yml
@@ -55,11 +55,11 @@ jobs:
         run: |
           git add README.md
           git add DESCRIPTION
-          git commit -m "[RELEASE] Set the release version to ${{ steps.release_version.outputs.version }}"
+          git commit -m "chore(release): set the release version to ${{ steps.release_version.outputs.version }}"
 
       - name: Tag ${{ steps.release_version.outputs.version }}
         run: |
-          git tag -a ${{ steps.release_version.outputs.version_tag }} -m "[RELEASE] ${{ steps.release_version.outputs.version }}"
+          git tag -a ${{ steps.release_version.outputs.version_tag }} -m "chore(release): ${{ steps.release_version.outputs.version }}"
 
       - name: Update with the development version
         run: |-
@@ -68,7 +68,7 @@ jobs:
       - name: Commit with the development version
         run: |
           git add DESCRIPTION
-          git commit -m "[RELEASE] Set the development version to ${{ steps.release_version.outputs.version }}.9000"
+          git commit -m "chore(release): set the development version to ${{ steps.release_version.outputs.version }}.9000"
 
       - name: Push commits and tags
         run: |

--- a/.github/workflows/release-bpmn_visualization.yml
+++ b/.github/workflows/release-bpmn_visualization.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout master
         run: git checkout master && git pull --tags
       - name: Bump Version
-        run: npm version ${{ github.event.inputs.type }} --message "[RELEASE] %s"
+        run: npm version ${{ github.event.inputs.type }} --message "chore(release) %s"
       - name: Push Version
         run: git push && git push --tags
 


### PR DESCRIPTION
Add a dedicated workflow to enforce the rule. It runs on `pull_request_target` to handle PR created by Dependabot and from fork repositories.
Dependabot configuration: change PR title prefix.
Update the GitHub workflows that create commits and PR. They now follow "conventional commits".