### PR TITLE
ci(slack): use another test channel

### DIFF
--- a/.github/workflows/slack-send-message.yml
+++ b/.github/workflows/slack-send-message.yml
@@ -4,9 +4,9 @@ on:
     inputs:
       channel-or-user:
         description: 'Send a message to a channel or a user (prefer usage of id instead of name).'
-        # C042KNPSN7N is a test channel
-        # CSF7TG6N5 is the production channel
-        default: 'C042KNPSN7N'
+        # C02J5M4JMK7 is a test channel
+        # vars.SLACK_CHANNEL_ID_NOTIFICATIONS is the production channel
+        default: 'C02J5M4JMK7'
         type: string
         required: true
 


### PR DESCRIPTION
 The previous one no longer exists.