### PR TITLE
ci: remove job that post Tweet

### DIFF
--- a/.github/workflows/announce-new-release.yml
+++ b/.github/workflows/announce-new-release.yml
@@ -12,25 +12,6 @@ on:
         required: true
 
 jobs:
-  tweet:
-    runs-on: ${{ vars.RUNNER_UBUNTU }}
-    steps:
-      - name: Tweet
-        uses: snow-actions/tweet@v1.4.0
-        with:
-          status: |
-            📣 test ${{ github.event.inputs.version }} is out! 🎉
-            
-            ${{ github.event.inputs.description }}
-        
-            #bpmnvisualization #bpmn #visualization #typescript #opensource
-            ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ github.event.inputs.version }}
-        env:
-          CONSUMER_API_KEY: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
-          CONSUMER_API_SECRET_KEY: ${{ secrets.TWITTER_CONSUMER_API_SECRET_KEY }}
-          ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-          ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
-
   send-message-on-discord:
     runs-on: ${{ vars.RUNNER_UBUNTU }}
     steps:


### PR DESCRIPTION
It is no longer possible to post a tweet with the API without a paid plan (and we only have a free plan). So, remove the automation.