### PR TITLE
ci(release): eliminate bypassing of branch protection

### DIFF
--- a/.github/workflows/release-R.yml
+++ b/.github/workflows/release-R.yml
@@ -14,14 +14,6 @@ jobs:
       - run: |
           echo "New version type: ${{ github.event.inputs.type }}"
 
-      - name: Branch Protection Bot - Temporarily disable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@1.0.9
-        if: always()
-        with:
-          access_token: ${{ secrets.GH_RELEASE_TOKEN }}
-          enforce_admins: false
-          branch: master
-
       - name: Setup checkout
         uses: actions/checkout@v4
         with:
@@ -73,11 +65,3 @@ jobs:
       - name: Push commits and tags
         run: |
           git push && git push --tags
-
-      - name: Branch Protection Bot - Reenable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@1.0.9
-        if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
-        with:
-          access_token: ${{ secrets.GH_RELEASE_TOKEN }}
-          enforce_admins: true
-          branch: master

--- a/.github/workflows/release-bpmn_visualization.yml
+++ b/.github/workflows/release-bpmn_visualization.yml
@@ -13,14 +13,6 @@ jobs:
     steps:
       - run: |
           echo "New version type: ${{ github.event.inputs.type }}"
-      - name: Branch Protection Bot - Temporarily disable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@1.0.9
-        if: always()
-        with:
-          access_token: ${{ secrets.GH_RELEASE_TOKEN }}
-          enforce_admins: false
-          branch: master
-
       - name: Setup node
         uses: actions/setup-node@v3
         with:
@@ -41,11 +33,3 @@ jobs:
           npm version ${{ github.event.inputs.type }} --message "chore(release): %s"
       - name: Push Version
         run: git push && git push --tags
-
-      - name: Branch Protection Bot - Reenable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@1.0.9
-        if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
-        with:
-          access_token: ${{ secrets.GH_RELEASE_TOKEN }}
-          enforce_admins: true
-          branch: master


### PR DESCRIPTION
The workflow commits to the main branch and the branch protection configured in the GitHub repository prevents this for all users.

Previously, the protection was temporarily bypassed and the user performing the commit required administrator permissions (due to the configuration of the branch protection).

Now protection is done using GitHub branch ruleset, and there's no need to bypass protection. In this way, workflow can be simplified.

### Notes

The settings have already been updated
- rulesets replaces branch and tag protection: https://github.com/process-analytics/bpmn-visualization-js/rules (publicly visible)
repository
- permissions of the user performing the Git operations in the repository has been downgraded. ⚠️ **IMPORTANT**: this PR must then be merged prior doing the next release. The workflow currently in the main branch requires this user to have more permissions. If executed, it will fail.

This configuration is already used in the following repositories
- `bv-experimental-add-ons`:
  - https://github.com/process-analytics/bv-experimental-add-ons/blob/v0.4.0/.github/workflows/release.yml
  - https://github.com/process-analytics/bv-experimental-add-ons/rules
- `bpmn-visualization-R`: see https://github.com/process-analytics/bpmn-visualization-R/pull/249
- `bpmn-visualization-js`: see https://github.com/process-analytics/bpmn-visualization-js/pull/2863

