### PR TITLE
ci: Use workflow run to upload surge preview

### DIFF
--- a/.github/workflows/surge-build-pr-artifact.yml
+++ b/.github/workflows/surge-build-pr-artifact.yml
@@ -1,0 +1,25 @@
+name: Surge PR Preview - Build Stage
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build-preview:
+    runs-on: ${{ vars.RUNNER_UBUNTU }}
+
+    steps:
+      - name: checkout PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: build dist
+        run: |
+          npm install
+          npm run site:build
+      - name: upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-build-dist
+          path: public/

--- a/.github/workflows/surge-upload.yml
+++ b/.github/workflows/surge-upload.yml
@@ -1,0 +1,28 @@
+name: Surge PR Preview - Upload Stage
+
+on:
+  workflow_run:
+    workflows: ["Surge PR Preview - Build Stage"]
+    types:
+      - completed
+
+jobs:
+  upload-preview:
+    runs-on: ${{ vars.RUNNER_UBUNTU }}
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: download dist artifact
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          name: pr-build-dist
+          path: public/
+
+      - name: deploy to Surge
+        uses: afc163/surge-preview@v1
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          build: echo done
+          dist: public


### PR DESCRIPTION
* Adding two workflows to try to build and deploy a surge preview from a fork