### PR TITLE
ci: surge-build uses public docs

### DIFF
--- a/.github/workflows/surge-build-pr-artifact.yml
+++ b/.github/workflows/surge-build-pr-artifact.yml
@@ -2,7 +2,11 @@ name: Surge PR Preview - Build Stage
 
 on:
   pull_request:
-
+    paths:
+      - '.github/worflows/surge-build-artifact.yml'
+      - '.github/worflows/surge-upload.yml'
+      - 'public/docs/index.html'
+      
 jobs:
   build-preview:
     runs-on: ubuntu-22.04
@@ -18,9 +22,9 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           mkdir site
-            echo "This is a preview site for <b>PR #${PR_NUMBER}</b>" > site/index.html
+          cp -r public/docs/index.html ./site
       - name: upload dist artifact
         uses: actions/upload-artifact@v4
         with:
           name: pr-build-dist
-          path: public/
+          path: site/

--- a/.github/workflows/surge-build-pr-artifact.yml
+++ b/.github/workflows/surge-build-pr-artifact.yml
@@ -3,10 +3,10 @@ name: Surge PR Preview - Build Stage
 on:
   pull_request:
     paths:
-      - '.github/worflows/surge-build-artifact.yml'
+      - '.github/worflows/surge-build-pr-artifact.yml'
       - '.github/worflows/surge-upload.yml'
       - 'public/docs/index.html'
-      
+
 jobs:
   build-preview:
     runs-on: ubuntu-22.04

--- a/.github/workflows/surge-upload.yml
+++ b/.github/workflows/surge-upload.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: pr-build-dist
-          path: public/
+          path: site/
 
       - name: deploy to Surge
         uses: afc163/surge-preview@v1
@@ -25,4 +25,4 @@ jobs:
           surge_token: ${{ secrets.SURGE_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build: echo done
-          dist: public
+          dist: site

--- a/.github/workflows/surge-upload.yml
+++ b/.github/workflows/surge-upload.yml
@@ -18,6 +18,9 @@ jobs:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: pr-build-dist
           path: site/
+      - name: Debug step
+        run: |
+          echo "${{github.event.payload.workflow_run}}"
 
       - name: deploy to Surge
         uses: afc163/surge-preview@v1

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -9,6 +9,6 @@
     <h1>Process Analytics Playground site</h1>
     <p>Have a look at an example of the <a href="api/">documentation of an TypeScript API generated with Typedoc</a></p>
 </section>
-<footer>Process Analytics - 2024-present</footer>
+<footer>Process Analytics - 2021-present</footer>
 </body>
 </html>

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -9,6 +9,6 @@
     <h1>Process Analytics Playground site</h1>
     <p>Have a look at an example of the <a href="api/">documentation of an TypeScript API generated with Typedoc</a></p>
 </section>
-<footer>Process Analytics - 2021-present</footer>
+<footer>Process Analytics - 2024-present</footer>
 </body>
 </html>


### PR DESCRIPTION
* Adding Paths to  run action only when specific will be updated
* Rename the upload artifact name