### PR TITLE
ci: fix name of the surge preview teardown workflow

### DIFF
--- a/.github/workflows/surge-pr-fork-03-teardown.yml
+++ b/.github/workflows/surge-pr-fork-03-teardown.yml
@@ -1,4 +1,4 @@
-name: Surge Preview for Pull Request
+name: Surge PR Preview - Teardown Stage
 
 on:
   pull_request_target:


### PR DESCRIPTION
It was using the same name as an existing workflow, so this mess the Actions list and the PR checks execution