### PR TITLE
chore(dependabot): group typescript related dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,11 @@ updates:
       - skip-changelog
     reviewers:
       - process-analytics/pa-collaborators
+    groups:
+       typescript:
+          patterns:
+            - "typedoc"
+            - "typescript"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`


### PR DESCRIPTION
When a minor version of TypeScript is released, typedoc must be updated as well.
This is because old typedoc versions don't support the new TypeScript version

### Notes

This is what we already do in https://github.com/process-analytics/bpmn-visualization-js/blob/e13994b2ddd23e7a242d0b781021dc41342faad5/.github/dependabot.yml
