### PR TITLE
fix: clean syntax when sending repository_dispatch

### DIFF
--- a/.github/workflows/post-release-simulate-new-version-available-on-npm.yml
+++ b/.github/workflows/post-release-simulate-new-version-available-on-npm.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           # use the default GITHUB_TOKEN, this is possible because we are dispatching the same repository
           event-type: new_version_available_on_npm
-          client-payload: "{ version: ${{ inputs.version }} }"
+          client-payload: '{ "version": "${{ inputs.version }}" }'


### PR DESCRIPTION
There were missing double quotes.

Covers https://github.com/process-analytics/bpmn-visualization-js/issues/2864
