### PR TITLE
ci: bump action-download-artifact from v7 to v8

### DIFF
--- a/.github/workflows/post-release-update_bpmn_visualization_version_in_Examples_repo.yml
+++ b/.github/workflows/post-release-update_bpmn_visualization_version_in_Examples_repo.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Delete old Demo
         run: rm -rf README.md
       - name: Download Demo ${{ env.VERSION }}
-        uses: dawidd6/action-download-artifact@v7
+        uses: dawidd6/action-download-artifact@v8
         with:
           github_token: ${{ secrets.GH_RELEASE_TOKEN }}
           repo: ${{ env.BUILD_DEMO_REPO }}

--- a/.github/workflows/surge-pr-fork-02-deploy.yml
+++ b/.github/workflows/surge-pr-fork-02-deploy.yml
@@ -26,7 +26,7 @@ jobs:
       #           echo "workflow_run: ${{toJSON(github.event.workflow_run)}}"
 
       - name: download dist artifact
-        uses: dawidd6/action-download-artifact@v7
+        uses: dawidd6/action-download-artifact@v8
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           run_id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
To test process-analytics/bpmn-visualization-examples#614

Tested with [https://github.com/process-analytics/github-actions-playground/actions/runs/12926209301/job/36048741946?pr=399](https://github.com/process-analytics/github-actions-playground/actions/runs/12926209301/job/36048741946?pr=399) and https://github.com/process-analytics/github-actions-playground/actions/runs/12926371059.