### PR TITLE
ci: build documentation with Node 22

### DIFF
--- a/.github/actions/build-documentation/action.yml
+++ b/.github/actions/build-documentation/action.yml
@@ -8,7 +8,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '22'
     - name: Install dependencies
       shell: bash
       run: npm ci


### PR DESCRIPTION
We were previously using Node 16 which is EOL and not supported by Typedoc, so warnings occured.
